### PR TITLE
Switch circ_buf usage to kfifo to match upstream serial/TTY changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ all:
 
 # Do our own clean, otherwise swig/serialsim.i gets removed
 clean:
-	rm -f *.o* *.ko *.mod*
+	rm -f  *.o*  *.ko*  *.mod*
+	rm -f .*.o* .*.ko* .*.mod*
+	rm -f *.symvers* .*.symvers*
 
 private_key.der: openssl.conf
 	openssl req -x509 -new -nodes -utf8 -sha256 -days 36500  \


### PR DESCRIPTION
Upstream replaced circ_buf with kfifo in the serial layer, introduced by commit [1788cf6a91d9](https://gbmc.googlesource.com/linux/+/1788cf6a91d9).

Here are the commands one can use for testing the changes in the newer kernels.

```
# Run the containers
podman run -it --rm -v .:/tmp/serialsim:Z --name centos10 centos:stream10
podman run -it --rm -v .:/tmp/serialsim:Z --name centos9  centos:stream9

# Compile inside the container of choice
dnf install -y kernel kernel-devel make python3-pyserial
KERNEL_VER=$(rpm -q --qf "%{VERSION}-%{RELEASE}\n" kernel | sort | tail -1)
KERNEL_VER_ARCH="${KERNEL_VER}.$(uname -m)"

make KERNEL="${KERNEL_VER_ARCH}" all
```